### PR TITLE
Sync Cases logic with new Roles field in Contentful

### DIFF
--- a/assets/css/components/_person.scss
+++ b/assets/css/components/_person.scss
@@ -6,3 +6,6 @@
   .person-role {
     @include font-size(12px);
   }
+  .person-role-title:not(:last-child):after {
+    content: ', ';
+  }

--- a/pages/cases/_slug.vue
+++ b/pages/cases/_slug.vue
@@ -102,11 +102,9 @@
     },
     computed: {
       cases() {
-        console.log(this.$store.state.caseData.cases)
         let cases = this.$store.state.caseData.cases.filter(
           el => el.fields.slug === this.slug
         );
-        console.log({cases})
         return cases[0];
       }
     },

--- a/pages/cases/_slug.vue
+++ b/pages/cases/_slug.vue
@@ -30,46 +30,21 @@
         <aside>
           <h2 class="list-header h6">Team</h2>
           <ul class="list-default">
-            <li v-if="cases.fields.teamMemberA">
+            <li v-for="(role, i) in cases.fields.roles" :key="'role-'+i">
               <div class="list-avatar">
-                <p class="avatar-small" v-if="cases.fields.teamMemberA.fields.avatar"><img :src="`${cases.fields.teamMemberA.fields.avatar.fields.file.url}`" /></p>
+                <p class="avatar-small" v-if="role.fields.member.fields.avatar"><img :src="`${role.fields.member.fields.avatar.fields.file.url}`" /></p>
               </div>
               <div class="list-content person">
-                <h3 class="h-mb-0 person-name">{{ cases.fields.teamMemberA.fields.name }}</h3>
-                <p class="person-role">{{ cases.fields.teamRoleA.fields.title }}</p>
-              </div>
-            </li>
-            <li v-if="cases.fields.teamMemberB">
-              <div class="list-avatar">
-                <p class="avatar-small" v-if="cases.fields.teamMemberB.fields.avatar"><img :src="`${cases.fields.teamMemberB.fields.avatar.fields.file.url}`" /></p>
-              </div>
-              <div class="list-content person">
-                <h3 class="h-mb-0 person-name">{{ cases.fields.teamMemberB.fields.name }}</h3>
-                <p class="person-role">{{ cases.fields.teamRoleB.fields.title }}</p>
-              </div>
-            </li>
-            <li v-if="cases.fields.teamMemberC">
-              <div class="list-avatar">
-                <p class="avatar-small" v-if="cases.fields.teamMemberC.fields.avatar"><img :src="`${cases.fields.teamMemberC.fields.avatar.fields.file.url}`" /></p>
-              </div>
-              <div class="list-content person">
-                <h3 class="h-mb-0 person-name">{{ cases.fields.teamMemberC.fields.name }}</h3>
-                <p class="person-role">{{ cases.fields.teamRoleC.fields.title }}</p>
-              </div>
-            </li>
-            <li v-if="cases.fields.teamMemberD">
-              <div class="list-avatar">
-                <p class="avatar-small" v-if="cases.fields.teamMemberD.fields.avatar"><img :src="`${cases.fields.teamMemberD.fields.avatar.fields.file.url}`" /></p>
-              </div>
-              <div class="list-content person">
-                <h3 class="h-mb-0 person-name">{{ cases.fields.teamMemberD.fields.name }}</h3>
-                <p class="person-role">{{ cases.fields.teamRoleD.fields.title }}</p>
+                <h3 class="h-mb-0 person-name">{{ role.fields.member.fields.name }}</h3>
+                <p class="person-role">
+                  <span class="person-role-title" v-for="discipline in role.fields.disciplines" :key="discipline.fields.title">{{discipline.fields.title}}</span>
+                </p>
               </div>
             </li>
           </ul>
         </aside>
       </div>
-      
+
       <div class="content-post-sidebar">
         <div class="content-inner" v-if="cases.fields.challenge">
           <h2 class="content-header h6">Challenge:</h2>
@@ -115,7 +90,7 @@
       </div>
     </section>
   </div>
-  
+
 </template>
 
 <script>
@@ -127,9 +102,11 @@
     },
     computed: {
       cases() {
+        console.log(this.$store.state.caseData.cases)
         let cases = this.$store.state.caseData.cases.filter(
           el => el.fields.slug === this.slug
         );
+        console.log({cases})
         return cases[0];
       }
     },

--- a/pages/collective/_slug.vue
+++ b/pages/collective/_slug.vue
@@ -14,7 +14,7 @@
           </li>
         </ul>
       </div>
-      
+
       <div v-if="member.fields.disciplines">
         <h2>Disciplines:</h2>
         <ul>
@@ -34,32 +34,12 @@
       </div>
       <div>
         <h2>Cases:</h2>
-        <div v-for="cases in cases">
-          <ul v-if="cases.fields.teamMemberA.fields.slug === member.fields.slug" v-for="team in cases.fields.teamMemberA">
-            <li v-if="team.slug === member.fields.slug" :key="cases.fields.slug">
-              <h2><NuxtLink :to="/cases/+`${cases.fields.slug}`">{{ cases.fields.title }}</NuxtLink></h2>
-              <p>{{ cases.fields.challenge }}</p>
-            </li>
-          </ul>
-          <ul v-if="cases.fields.teamMemberB.fields.slug === member.fields.slug" v-for="team in cases.fields.teamMemberB">
-            <li v-if="team.slug === member.fields.slug" :key="cases.fields.slug">
-              <h2><NuxtLink :to="/cases/+`${cases.fields.slug}`">{{ cases.fields.title }}</NuxtLink></h2>
-              <p>{{ cases.fields.challenge }}</p>
-            </li>
-          </ul>
-          <ul v-if="cases.fields.teamMemberC.fields.slug === member.fields.slug" v-for="team in cases.fields.teamMemberC">
-            <li v-if="team.slug === member.fields.slug" :key="cases.fields.slug">
-              <h2><NuxtLink :to="/cases/+`${cases.fields.slug}`">{{ cases.fields.title }}</NuxtLink></h2>
-              <p>{{ cases.fields.challenge }}</p>
-            </li>
-          </ul>
-          <ul v-if="cases.fields.teamMemberD.fields.slug === member.fields.slug" v-for="team in cases.fields.teamMemberD">
-            <li v-if="team.slug === member.fields.slug" :key="cases.fields.slug">
-              <h2><NuxtLink :to="/cases/+`${cases.fields.slug}`">{{ cases.fields.title }}</NuxtLink></h2>
-              <p>{{ cases.fields.challenge }}</p>
-            </li>
-          </ul>
-        </div>
+        <ul>
+          <li v-for="caseStudy in cases" :key="caseStudy.fields.slug">
+            <h2><NuxtLink :to="/cases/+`${caseStudy.fields.slug}`">{{ caseStudy.fields.title }}</NuxtLink></h2>
+            <p>{{ caseStudy.fields.challenge }}</p>
+          </li>
+        </ul>
       </div>
 
       <div>
@@ -94,7 +74,11 @@
         return member[0];
       },
       cases() {
-        return this.$store.state.caseData.cases;
+        return this.$store.state.caseData.cases.filter((caseStudy) => {
+          if (caseStudy.fields.roles) {
+            return caseStudy.fields.roles.filter((role) => role.fields.member.fields.slug === this.slug);
+          }
+        });
       },
       ventures() {
         return this.$store.state.ventureData.ventures;


### PR DESCRIPTION
This is the new Roles field:

<img width="848" alt="Screen Shot 2022-09-29 at 1 25 58 PM" src="https://user-images.githubusercontent.com/13770535/193124271-12d4f1e6-356a-4a87-ae62-d5d0f6bf884d.png">

So you're just gonna title it like this: "MEMBER on DISCIPLINE(S)" The title doesn't matter, it's for internal use only, but it's also unique so it won't let you create duplicates.

Then choose a member and fill in their disciplines.

I added a Roles reference field in the Cases content type so you can choose as many or as few team members on each project.

This is a screenshot of how the site looks with this new Role reference:

<img width="358" alt="Screen Shot 2022-09-29 at 1 21 33 PM" src="https://user-images.githubusercontent.com/13770535/193124630-da94e670-3f6a-44ec-ba0e-af8b62db79af.png">

Roles are each in a `span` so a pseudoselector adds a comma after except on the last/only item.

<img width="360" alt="Screen Shot 2022-09-29 at 1 22 28 PM" src="https://user-images.githubusercontent.com/13770535/193124812-27c9d3be-251b-4c72-a41e-f447fab1ff40.png">

Let me know if anything else.